### PR TITLE
Updated version of log4j to 2.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ def versions = [
   junit           : '5.7.2',
   junitPlatform   : '1.7.2',
   reformLogging   : '5.1.7',
-  spring : '2.5.3'
+  spring : '2.5.5'
 ]
 
 ext.libraries = [
@@ -134,6 +134,14 @@ ext.libraries = [
     "org.junit.platform:junit-platform-engine:${versions.junitPlatform}"
   ]
 ]
+
+configurations.all {
+  resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+    if (details.requested.group == 'org.apache.logging.log4j') {
+      details.useVersion '2.15.0'
+    }
+  }
+}
 
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: "${versions.spring}"
@@ -151,3 +159,5 @@ dependencies {
 wrapper {
     distributionType = Wrapper.DistributionType.ALL
 }
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ def versions = [
   junit           : '5.7.2',
   junitPlatform   : '1.7.2',
   reformLogging   : '5.1.7',
-  spring : '2.5.5'
+  spring : '2.5.7'
 ]
 
 ext.libraries = [


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Updated version of log4j to 2.15.0 following vulnerability in library

See https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot for details.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```