### PR TITLE
PUB-2119 - Updated dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@ plugins {
   id 'checkstyle'
   id 'pmd'
   id 'jacoco'
-  id 'io.spring.dependency-management' version '1.1.0'
+  id 'io.spring.dependency-management' version '1.1.2'
   id 'org.owasp.dependencycheck' version '8.3.1'
   id 'com.github.ben-manes.versions' version '0.47.0'
-  id 'org.sonarqube' version '4.2.1.3168'
+  id 'org.sonarqube' version '4.3.0.3225'
   id 'io.freefair.lombok' version '8.1.0'
   id 'maven-publish'
 }
@@ -20,7 +20,7 @@ publishing {
 }
 
 group = 'com.github.hmcts'
-version = '2.1.3'
+version = '2.1.4'
 
 java {
   toolchain {
@@ -121,10 +121,10 @@ repositories {
 }
 
 def versions = [
-  junit           : '5.9.3',
+  junit           : '5.10.0',
   junitPlatform   : '1.9.3',
   reformLogging   : '5.1.7',
-  spring : '3.0.8'
+  spring : '3.1.2'
 ]
 
 configurations.all {
@@ -142,9 +142,9 @@ dependencies {
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
 
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: "2.15.2"
-  implementation 'com.opencsv:opencsv:5.7.1'
+  implementation 'com.opencsv:opencsv:5.8'
 
-  testImplementation(platform('org.junit:junit-bom:5.9.3'))
+  testImplementation(platform('org.junit:junit-bom:5.10.0'))
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: "${versions.spring}", {
     exclude group: 'junit', module: 'junit'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
-
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2119

### Change description ###

Spring Dependency Management to 1.1.2
Spring Boot to 3.1.2
Sonarqube to 4.3.0.3225
jUnit to 5.10.0
OpenCsv to 5.8
Gradle version to 8.2.1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
